### PR TITLE
ci(release): add issues permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 name: release-please


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change grants write permissions to issues.